### PR TITLE
feat(repo): Add version bump commands and scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/sentry-unplugin-root",
-  "version": "0.0.0",
+  "version": "2.0.0-alpha.0",
   "description": "Root of the sentry unplugin monorepo.",
   "repository": "git@github.com:lforst/sentry-unplugin.git",
   "private": true,
@@ -16,13 +16,14 @@
     "lint": "nx run-many --target=lint --all",
     "check:formatting": "prettier --check .",
     "fix:formatting": "prettier --write .",
-    "prepare": "husky install"
+    "prepare": "husky install",
+    "bump:version": "bash ./scripts/bump_version.sh"
   },
   "devDependencies": {
     "@nrwl/cli": "14.5.10",
     "@nrwl/workspace": "14.5.10",
-    "nx": "14.5.10",
     "husky": "^8.0.0",
+    "nx": "14.5.10",
     "prettier": "^2.7.1",
     "pretty-quick": "^3.1.3"
   }

--- a/packages/esbuild-plugin/package.json
+++ b/packages/esbuild-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/esbuild-plugin",
-  "version": "0.0.1",
+  "version": "2.0.0-alpha.0",
   "description": "Official Sentry esbuild plugin",
   "repository": "git://github.com/getsentry/sentry-unplugin.git",
   "homepage": "https://github.com/getsentry/sentry-unplugin/tree/main/packages/esbuild-plugin",
@@ -32,7 +32,8 @@
     "check:types:src": "tsc --project ./src/tsconfig.json --noEmit",
     "check:types:test": "tsc --project ./test/tsconfig.json --noEmit",
     "test": "jest",
-    "lint": "eslint ./src ./test"
+    "lint": "eslint ./src ./test",
+    "bump:version": "yarn version --no-git-tag-version --new-version"
   },
   "dependencies": {
     "@sentry/sentry-unplugin": "0.0.1"
@@ -45,12 +46,12 @@
     "@rollup/plugin-commonjs": "22.0.1",
     "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "13.3.0",
+    "@sentry-internal/eslint-config": "*",
+    "@sentry-internal/sentry-unplugin-tsconfig": "*",
     "@swc/core": "^1.2.205",
     "@swc/jest": "^0.2.21",
     "@types/jest": "^28.1.3",
     "@types/node": "^18.6.3",
-    "@sentry-internal/eslint-config": "*",
-    "@sentry-internal/sentry-unplugin-tsconfig": "*",
     "eslint": "^8.18.0",
     "jest": "^28.1.1",
     "npm-run-all": "^4.1.5",

--- a/packages/eslint-configs/package.json
+++ b/packages/eslint-configs/package.json
@@ -1,8 +1,11 @@
 {
   "name": "@sentry-internal/eslint-config",
-  "version": "0.0.0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "private": true,
+  "scripts": {
+    "bump:version": "yarn version --no-git-tag-version --new-version"
+  },
   "peerDependencies": {
     "eslint": "^8.14.0"
   },

--- a/packages/integration-tests/package.json
+++ b/packages/integration-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry-internal/integration-tests",
-  "version": "0.0.0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "private": true,
   "scripts": {
@@ -8,20 +8,21 @@
     "test:setup": "ts-node scripts/run-fixture-setups.ts",
     "test:jest": "jest",
     "lint": "eslint .",
-    "check:types": "tsc --project ./tsconfig.json --noEmit"
+    "check:types": "tsc --project ./tsconfig.json --noEmit",
+    "bump:version": "yarn version --no-git-tag-version --new-version"
   },
   "dependencies": {
-    "@swc/jest": "^0.2.21",
-    "@types/jest": "^28.1.3",
-    "@sentry/sentry-unplugin": "*",
-    "@types/webpack4": "npm:@types/webpack@4.41.32",
     "@sentry-internal/eslint-config": "*",
     "@sentry-internal/sentry-unplugin-tsconfig": "*",
+    "@sentry/sentry-unplugin": "*",
+    "@swc/jest": "^0.2.21",
+    "@types/jest": "^28.1.3",
+    "@types/webpack4": "npm:@types/webpack@4.41.32",
     "esbuild": "0.14.49",
+    "eslint": "^8.18.0",
     "jest": "^28.1.3",
     "npm-run-all": "4.1.5",
     "rollup": "2.77.0",
-    "eslint": "^8.18.0",
     "ts-node": "^10.9.1",
     "vite": "3.0.0",
     "webpack": "5.74.0",

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry-internal/unplugin-playground",
-  "version": "0.0.0",
+  "version": "2.0.0-alpha.0",
   "license": "MIT",
   "private": true,
   "scripts": {
@@ -11,7 +11,8 @@
     "build:webpack5": "node build-webpack5.js",
     "build:esbuild": "node build-esbuild.js",
     "build:smallNodeApp": "vite build --config vite.config.smallNodeApp.js",
-    "start:proxyLogger": "ts-node scripts/request-logger-proxy.ts"
+    "start:proxyLogger": "ts-node scripts/request-logger-proxy.ts",
+    "bump:version": "yarn version --no-git-tag-version --new-version"
   },
   "dependencies": {
     "@sentry/integrations": "^7.11.1",

--- a/packages/rollup-plugin/package.json
+++ b/packages/rollup-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/rollup-plugin",
-  "version": "0.0.1",
+  "version": "2.0.0-alpha.0",
   "description": "Official Sentry Rollup plugin",
   "repository": "git://github.com/getsentry/sentry-unplugin.git",
   "homepage": "https://github.com/getsentry/sentry-unplugin/tree/main/packages/rollup-plugin",
@@ -33,7 +33,8 @@
     "check:types:src": "tsc --project ./src/tsconfig.json --noEmit",
     "check:types:test": "tsc --project ./test/tsconfig.json --noEmit",
     "test": "jest",
-    "lint": "eslint ./src ./test"
+    "lint": "eslint ./src ./test",
+    "bump:version": "yarn version --no-git-tag-version --new-version"
   },
   "dependencies": {
     "@sentry/sentry-unplugin": "0.0.1"
@@ -46,12 +47,12 @@
     "@rollup/plugin-commonjs": "22.0.1",
     "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "13.3.0",
+    "@sentry-internal/eslint-config": "*",
+    "@sentry-internal/sentry-unplugin-tsconfig": "*",
     "@swc/core": "^1.2.205",
     "@swc/jest": "^0.2.21",
     "@types/jest": "^28.1.3",
     "@types/node": "^18.6.3",
-    "@sentry-internal/eslint-config": "*",
-    "@sentry-internal/sentry-unplugin-tsconfig": "*",
     "eslint": "^8.18.0",
     "jest": "^28.1.1",
     "npm-run-all": "^4.1.5",

--- a/packages/tsconfigs/package.json
+++ b/packages/tsconfigs/package.json
@@ -1,6 +1,9 @@
 {
   "name": "@sentry-internal/sentry-unplugin-tsconfig",
-  "version": "0.0.0",
+  "version": "2.0.0-alpha.0",
+  "scripts": {
+    "bump:version": "yarn version --no-git-tag-version --new-version"
+  },
   "license": "MIT",
   "private": true
 }

--- a/packages/unplugin/package.json
+++ b/packages/unplugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/sentry-unplugin",
-  "version": "0.0.1",
+  "version": "2.0.0-alpha.0",
   "description": "Official Sentry unplugin",
   "repository": "git://github.com/getsentry/sentry-unplugin.git",
   "homepage": "https://github.com/getsentry/sentry-unplugin",
@@ -26,7 +26,8 @@
     "check:types:src": "tsc --project ./src/tsconfig.json --noEmit",
     "check:types:test": "tsc --project ./test/tsconfig.json --noEmit",
     "test": "jest",
-    "lint": "eslint ./src ./test"
+    "lint": "eslint ./src ./test",
+    "bump:version": "yarn version --no-git-tag-version --new-version"
   },
   "dependencies": {
     "@sentry/node": "^7.11.1",

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/vite-plugin",
-  "version": "0.0.1",
+  "version": "2.0.0-alpha.0",
   "description": "Official Sentry Vite plugin",
   "repository": "git://github.com/getsentry/sentry-unplugin.git",
   "homepage": "https://github.com/getsentry/sentry-unplugin/tree/main/packages/vite-plugin",
@@ -32,7 +32,8 @@
     "check:types:src": "tsc --project ./src/tsconfig.json --noEmit",
     "check:types:test": "tsc --project ./test/tsconfig.json --noEmit",
     "test": "jest",
-    "lint": "eslint ./src ./test"
+    "lint": "eslint ./src ./test",
+    "bump:version": "yarn version --no-git-tag-version --new-version"
   },
   "dependencies": {
     "@sentry/sentry-unplugin": "0.0.1"
@@ -45,12 +46,12 @@
     "@rollup/plugin-commonjs": "22.0.1",
     "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "13.3.0",
+    "@sentry-internal/eslint-config": "*",
+    "@sentry-internal/sentry-unplugin-tsconfig": "*",
     "@swc/core": "^1.2.205",
     "@swc/jest": "^0.2.21",
     "@types/jest": "^28.1.3",
     "@types/node": "^18.6.3",
-    "@sentry-internal/eslint-config": "*",
-    "@sentry-internal/sentry-unplugin-tsconfig": "*",
     "eslint": "^8.18.0",
     "jest": "^28.1.1",
     "npm-run-all": "^4.1.5",

--- a/packages/webpack-plugin/package.json
+++ b/packages/webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/webpack-plugin",
-  "version": "0.0.1",
+  "version": "2.0.0-alpha.0",
   "description": "Official Sentry Webpack plugin",
   "repository": "git://github.com/getsentry/sentry-unplugin.git",
   "homepage": "https://github.com/getsentry/sentry-unplugin/tree/main/packages/webpack-plugin",
@@ -33,7 +33,8 @@
     "check:types:src": "tsc --project ./src/tsconfig.json --noEmit",
     "check:types:test": "tsc --project ./test/tsconfig.json --noEmit",
     "test": "jest",
-    "lint": "eslint ./src ./test"
+    "lint": "eslint ./src ./test",
+    "bump:version": "yarn version --no-git-tag-version --new-version"
   },
   "dependencies": {
     "@sentry/sentry-unplugin": "0.0.1"
@@ -46,12 +47,12 @@
     "@rollup/plugin-commonjs": "22.0.1",
     "@rollup/plugin-json": "4.1.0",
     "@rollup/plugin-node-resolve": "13.3.0",
+    "@sentry-internal/eslint-config": "*",
+    "@sentry-internal/sentry-unplugin-tsconfig": "*",
     "@swc/core": "^1.2.205",
     "@swc/jest": "^0.2.21",
     "@types/jest": "^28.1.3",
     "@types/node": "^18.6.3",
-    "@sentry-internal/eslint-config": "*",
-    "@sentry-internal/sentry-unplugin-tsconfig": "*",
     "eslint": "^8.18.0",
     "jest": "^28.1.1",
     "npm-run-all": "^4.1.5",

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -1,0 +1,3 @@
+echo version $1
+yarn nx run-many --target bump:version $1 --all &&
+yarn version --no-git-tag-version --new-version $1


### PR DESCRIPTION
This PR adds a yarn script (`bump:version`) to all repo projects. It calles `yarn version` to use yarn for setting a new version to the package.json files. To also bump the top level package.json version, this PR adds a small bash script to first execute the bump in all packages and then set the same version in the main repo project. 

We need something like this to set up releases