### PR TITLE
chore: Update READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,27 +4,29 @@
   </a>
 </p>
 
-# Sentry Unplugin
+# Sentry Unplugin (WIP)
 
-**DISCLAIMER: This package is work in progress and not production ready. Use with caution. We're happy to receive your feedback!**
+**WARNING: This project is work in progress! Do not yet use it in production. We're happy to receive your feedback!**
 
 Universal Sentry plugin for various JavaScript bundlers. Based on [unjs/uplugin](https://github.com/unjs/unplugin). Currently supports Rollup, Vite, esbuild, Webpack 4 and Webpack 5.
 
 Check out the individual packages for more information and examples:
 
-- [Rollup](https://github.com/getsentry/hackweek-sentry-unplugin/tree/main/packages/rollup-plugin)
-- [Vite](https://github.com/getsentry/hackweek-sentry-unplugin/tree/main/packages/vite-plugin)
-- [esbuild](https://github.com/getsentry/hackweek-sentry-unplugin/tree/main/packages/esbuild-plugin)
-- [Webpack](https://github.com/getsentry/hackweek-sentry-unplugin/tree/main/packages/webpack-plugin)
+- [Rollup](https://github.com/getsentry/sentry-unplugin/tree/main/packages/rollup-plugin)
+- [Vite](https://github.com/getsentry/sentry-unplugin/tree/main/packages/vite-plugin)
+- [esbuild](https://github.com/getsentry/sentry-unplugin/tree/main/packages/esbuild-plugin)
+- [Webpack](https://github.com/getsentry/sentry-unplugin/tree/main/packages/webpack-plugin)
 
 ### Features
 
-The Sentry Unplugin supports [Sentry CLI](https://docs.sentry.io/learn/cli/) features required for node environments:
+The Sentry Unplugin take care of Sentry-related tasks at build time of your JavaScript projects. It supports the following features:
 
 - Sourcemap upload
 - Release creation in Sentry
 - Automatic release name discovery (based on CI environment - Vercel, AWS, Heroku, CircleCI, or current Git SHA)
 - Automatically associate errors with releases (Release injection)
+
+The Sentry Unplugin can be used as a replacement of [Sentry CLI](https://docs.sentry.io/learn/cli/) for these tasks.
 
 ### More information
 

--- a/packages/esbuild-plugin/README.md
+++ b/packages/esbuild-plugin/README.md
@@ -4,9 +4,9 @@
   </a>
 </p>
 
-# Sentry Esbuild Plugin
+# Sentry Esbuild Plugin (WIP)
 
-**DISCLAIMER: This package is work in progress and not production ready. Use with caution. We're happy to receive your feedback!**
+**WARNING: This package is work in progress! Use with caution and do not yet use it in production. We're happy to receive your feedback!**
 
 A esbuild plugin that provides release management features for Sentry:
 

--- a/packages/rollup-plugin/README.md
+++ b/packages/rollup-plugin/README.md
@@ -6,7 +6,7 @@
 
 # Sentry Rollup Plugin
 
-**DISCLAIMER: This package is work in progress and not production ready. Use with caution. We're happy to receive your feedback!**
+**WARNING: This package is work in progress! Use with caution and do not yet use it in production. We're happy to receive your feedback!**
 
 A Rollup plugin that provides release management features for Sentry:
 

--- a/packages/unplugin/README.md
+++ b/packages/unplugin/README.md
@@ -1,0 +1,37 @@
+<p align="center">
+  <a href="https://sentry.io/?utm_source=github&utm_medium=logo" target="_blank">
+    <img src="https://sentry-brand.storage.googleapis.com/sentry-wordmark-dark-280x84.png" alt="Sentry" width="280" height="84">
+  </a>
+</p>
+
+# Sentry Unplugin (WIP)
+
+**WARNING: This package is work in progress! Do not yet use it in production. We're happy to receive your feedback!**
+
+Core package containing the bundler-agnostic functionality used by the bundler plugins.
+
+Check out the individual packages for more information and examples:
+
+- [Rollup](https://github.com/getsentry/sentry-unplugin/tree/main/packages/rollup-plugin)
+- [Vite](https://github.com/getsentry/sentry-unplugin/tree/main/packages/vite-plugin)
+- [esbuild](https://github.com/getsentry/sentry-unplugin/tree/main/packages/esbuild-plugin)
+- [Webpack](https://github.com/getsentry/sentry-unplugin/tree/main/packages/webpack-plugin)
+
+### Features
+
+The Sentry Unplugin take care of Sentry-related tasks at build time of your JavaScript projects. It supports the following features:
+
+- Sourcemap upload
+- Release creation in Sentry
+- Automatic release name discovery (based on CI environment - Vercel, AWS, Heroku, CircleCI, or current Git SHA)
+- Automatically associate errors with releases (Release injection)
+
+The Sentry Unplugin can be used as a replacement of [Sentry CLI](https://docs.sentry.io/learn/cli/) for these tasks.
+
+### More information
+
+- [Sentry Documentation](https://docs.sentry.io/quickstart/)
+- [Troubleshooting Sourcemaps](https://docs.sentry.io/platforms/javascript/sourcemaps/troubleshooting_js/)
+- [Sentry CLI](https://docs.sentry.io/learn/cli/)
+- [Sentry Discord](https://discord.gg/Ww9hbqr)
+- [Sentry Stackoverflow](http://stackoverflow.com/questions/tagged/sentry)

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -4,9 +4,9 @@
   </a>
 </p>
 
-# Sentry Vite Plugin
+# Sentry Vite Plugin (WIP)
 
-**DISCLAIMER: This package is work in progress and not production ready. Use with caution. We're happy to receive your feedback!**
+**WARNING: This package is work in progress! Use with caution and do not yet use it in production. We're happy to receive your feedback!**
 
 A Vite plugin that provides release management features for Sentry:
 

--- a/packages/webpack-plugin/README.md
+++ b/packages/webpack-plugin/README.md
@@ -4,9 +4,9 @@
   </a>
 </p>
 
-# Sentry Webpack Plugin
+# Sentry Webpack Plugin (WIP)
 
-**DISCLAIMER: This package is work in progress and not production ready. Use with caution. We're happy to receive your feedback!**
+**WARNING: This package is work in progress! Use with caution and do not yet use it in production. We're happy to receive your feedback!**
 
 A Webpack plugin that provides release management features for Sentry:
 


### PR DESCRIPTION
This updates and adds `README.md` files across the packages we want to release.
- removes old `hackweek-sentry-unplugin` links
- makes warnings that this is a heavy WIP more explicit
- adds Readme to the core sentry-unplugin package