### PR TITLE
chore: Add CHANGELOG.md file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
+- "You know what they say ‘Fool me once, strike one, but fool me twice… strike three.’" — Michael Scott
 
 ## 0.0.0-alpha.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## Unreleased
+
+- "You miss 100 percent of the chances you don't take. — Wayne Gretzky" — Michael Scott
+
+## 0.0.0-alpha.0
+
+This release marks the first release of the Sentry bundler blugins. This is still a heavy work in progress and a lot of things are still missing and subject to change
+
+- Initial release


### PR DESCRIPTION
This adds an almost empty `CHANGELOG.md` file to the repo. I created an initial (yet unreleased) release to have at least something there. Other than that this is a plain copy from the [JS SDK repo's changelog](https://github.com/getsentry/sentry-javascript/blob/052aa6b0fa551aacdc1318494f7eeaf7b53f2e1f/CHANGELOG.md#L1). 

Not sure yet what's gonna go into the first release or when/how that happens so we might need an additional PR for that when we get to it.